### PR TITLE
Fix channel alignment

### DIFF
--- a/python/myelin/__init__.py
+++ b/python/myelin/__init__.py
@@ -1,0 +1,2 @@
+from builder import *
+from flow import *

--- a/python/myelin/lexical_encoder.py
+++ b/python/myelin/lexical_encoder.py
@@ -75,7 +75,7 @@ class LexicalEncoder:
     bldr.rename(self.feature_vector, "feature_vector")
     self.feature_vector.ref = True
 
-    # Add BiLSTM. 
+    # Add BiLSTM.
     lr = builder.Builder(flow, "lstm/lr")
     lr_input = lr.var(name="input", shape=[1, spec.lstm_input_dim])
     lr_input.ref = True
@@ -90,5 +90,8 @@ class LexicalEncoder:
     rl_lstm.copy_to_flow_lstm(flow_rl_lstm)
     self.rl_lstm = flow_rl_lstm
 
-    bldr = builder.Builder(flow, "lstm")
-    bldr.cnx("lstm_input", [self.feature_vector, lr_input, rl_input])
+    cnxin = flow.cnx("features")
+    cnxin.add(self.feature_vector)
+    cnxin.add(lr_input)
+    cnxin.add(rl_input)
+

--- a/sling/myelin/analyze.cc
+++ b/sling/myelin/analyze.cc
@@ -45,6 +45,7 @@ DEFINE_string(graph, "", "DOT file name for flow");
 DEFINE_bool(consts, true, "Include constants in DOT graph");
 DEFINE_string(datagraph, "", "DOT file name prefix for data profile");
 DEFINE_int32(batch, 1, "Batch size");
+DEFINE_int32(codealign, 16, "Alignment of code objects");
 DEFINE_string(o, "", "ELF object output file for generated code");
 DEFINE_bool(gendata, false, "Output tensor data to ELF object file");
 DEFINE_bool(genrwdata, false, "Allocate space for tensor data in object file");
@@ -161,6 +162,7 @@ int main(int argc, char *argv[]) {
         linker_opts.generate_data = true;
         linker_opts.writeable_data = true;
       }
+      linker_opts.code_align = FLAGS_codealign;
       linker = new ElfLinker(linker_opts);
       network.set_linker(linker);
     }

--- a/sling/myelin/elf-linker.cc
+++ b/sling/myelin/elf-linker.cc
@@ -21,7 +21,7 @@ namespace myelin {
 
 void ElfLinker::BeginCell(Cell *cell) {
   // Align code buffer before generating new cell computation function.
-  code_.Align(16);
+  code_.Align(options_.code_align);
 }
 
 void ElfLinker::EndStep(Step *step, int offset) {

--- a/sling/myelin/elf-linker.h
+++ b/sling/myelin/elf-linker.h
@@ -34,6 +34,9 @@ class ElfLinker : public Linker {
 
     // Generate writeable uninitalized data section with model parameters.
     bool writeable_data = false;
+
+    // Code alignment.
+    int code_align = 16;
   };
 
   ElfLinker(const Options &options) : options_(options) {}

--- a/sling/nlp/document/lexical-encoder.cc
+++ b/sling/nlp/document/lexical-encoder.cc
@@ -376,14 +376,6 @@ myelin::BiChannel LexicalEncoderInstance::Compute(const Document &document,
   return bilstm_.Compute(&fv_);
 }
 
-void LexicalEncoderInstance::set_profile(myelin::ProfileSummary *fv,
-                                         myelin::ProfileSummary *lr,
-                                         myelin::ProfileSummary *rl) {
-  features_.set_profile(fv);
-  bilstm_.set_lr_profile(lr);
-  bilstm_.set_rl_profile(rl);
-}
-
 myelin::BiChannel LexicalEncoderLearner::Compute(const Document &document,
                                                  int begin, int end) {
   // Extract feature and map through feature embeddings.

--- a/sling/nlp/document/lexical-encoder.h
+++ b/sling/nlp/document/lexical-encoder.h
@@ -137,9 +137,6 @@ class LexicalFeatureExtractor {
   // Data instance for feature extraction.
   myelin::Instance *data() { return &data_; }
 
-  // Set profile summary.
-  void set_profile(myelin::ProfileSummary *s) { data_.set_profile(s); }
-
  private:
   const LexicalFeatures &lex_;
   myelin::Instance data_;
@@ -238,11 +235,6 @@ class LexicalEncoderInstance {
   // encoder. Returns the left-to-right and right-to-left channels for the
   // hidden state of the LSTMs.
   myelin::BiChannel Compute(const Document &document, int begin, int end);
-
-  // Set dedicated profile computation summaries for the various cells.
-  void set_profile(myelin::ProfileSummary *fv,
-                   myelin::ProfileSummary *lr,
-                   myelin::ProfileSummary *rl);
 
  private:
   const LexicalEncoder &encoder_;

--- a/sling/nlp/parser/BUILD
+++ b/sling/nlp/parser/BUILD
@@ -70,7 +70,6 @@ cc_library(
     "//sling/frame:store",
     "//sling/myelin:compute",
     "//sling/myelin:flow",
-    "//sling/myelin:profile",
     "//sling/myelin/kernel:cuda",
     "//sling/myelin/kernel:dragnn",
     "//sling/myelin/kernel:tensorflow",

--- a/sling/nlp/parser/tools/BUILD
+++ b/sling/nlp/parser/tools/BUILD
@@ -9,6 +9,7 @@ cc_binary(
     "//sling/file:posix",
     "//sling/frame:object",
     "//sling/frame:serialization",
+    "//sling/myelin:profile",
     "//sling/nlp/document",
     "//sling/nlp/document:document-source",
     "//sling/nlp/document:document-tokenizer",

--- a/sling/nlp/parser/tools/parse.cc
+++ b/sling/nlp/parser/tools/parse.cc
@@ -37,6 +37,7 @@
 #include "sling/base/flags.h"
 #include "sling/frame/object.h"
 #include "sling/frame/serialization.h"
+#include "sling/myelin/profile.h"
 #include "sling/nlp/document/document.h"
 #include "sling/nlp/document/document-source.h"
 #include "sling/nlp/document/document-tokenizer.h"
@@ -238,17 +239,11 @@ int main(int argc, char *argv[]) {
 
   // Output profile report.
   if (FLAGS_profile) {
-    myelin::Profile features(&parser.profile()->features);
-    std::cout << features.ASCIIReport() << "\n";
-
-    myelin::Profile lr(&parser.profile()->lr);
-    std::cout << lr.ASCIIReport() << "\n";
-
-    myelin::Profile rl(&parser.profile()->rl);
-    std::cout << rl.ASCIIReport() << "\n";
-
-    myelin::Profile ff(&parser.profile()->ff);
-    std::cout << ff.ASCIIReport() << "\n";
+    for (auto *cell : parser.network().cells()) {
+      myelin::Profile profile(cell->profile_summary());
+      string report = profile.ASCIIReport();
+      std::cout << report << "\n";
+    }
   }
 
   return 0;

--- a/sling/nlp/parser/trainer/pytorch_modules.py
+++ b/sling/nlp/parser/trainer/pytorch_modules.py
@@ -553,6 +553,7 @@ class Sempar(nn.Module):
     # Add link and connector for previous FF steps.
     ff_cnx = ff.cnx("step", args=[])
     ff_steps = link(ff, "steps", spec.ff_hidden_dim, ff_cnx, False)
+    ff_cnx.add(fl.var("ff/hidden:0"))
 
     # Add FF's input variables.
     for feature in spec.ff_fixed_features:


### PR DESCRIPTION
The crash in the parser runtime on the small model was due to an alignment issue for channels with small elements. I now ensure that the element size in the channel is not smaller than the byte alignment for the channel elements.

I have also fixed a few other minor issues:
* Use global profiling for the parser to avoid having to set the profiling tensor in each instance.
* I have added a missing connection between the steps and the hidden activation for the ff cell.
* Removed the empty "lstm" cell by making the connector directly
* Added missing `__init__.py` to sling.myelin package.
* Added an option to specify code alignment for the analyzer tool to make it easier to match code addresses from crashes.
* I have added an alignment check in debug mode that check if a tensor reference has the correct alignment for the tensor format. This should allow us to catch more alignment bugs.
