### PR TITLE
Fix channel alignment issue

### DIFF
--- a/sling/myelin/compute.cc
+++ b/sling/myelin/compute.cc
@@ -620,9 +620,12 @@ string Tensor::ToString(const char *data, bool deref) const {
 }
 
 Channel::Channel(const Tensor *format) : format_(format) {
-  // Elements must be aligned to the alignment of the tensor format.
-  element_size_ = format->size();
-  EnsureAlignment(&element_size_, format->byte_alignment());
+  // Use the stride of the first dimension as the element size to ensure
+  // proper alignment of the elements in the channel array.
+  DCHECK(format->order() == ROW_MAJOR) << format->name();
+  DCHECK_GE(format->rank(), 1) << format->name();
+  DCHECK_EQ(format->dim(0), 1) << format->name();
+  element_size_ = format->stride(0);
 
   // Channel are aligned to the element alignment and cache lines.
   EnsureAlignment(&alignment_, format->byte_alignment());
@@ -1231,6 +1234,7 @@ bool Network::Compile(const Flow &flow, const Library &library) {
 
     // Compute stride size for each dimension.
     size_t size = TypeTraits::of(tensor->type()).size();
+    int outer;
     if (tensor->order_ == ROW_MAJOR) {
       for (int d = tensor->rank() - 1; d >= 0; --d) {
         tensor->stride_.set(d, size);
@@ -1240,6 +1244,7 @@ bool Network::Compile(const Flow &flow, const Library &library) {
         tensor->aligned_.set(d, align);
         size *= align;
       }
+      outer = 0;
     } else {
       for (int d = 0; d < tensor->rank(); ++d) {
         tensor->stride_.set(d, size);
@@ -1249,7 +1254,20 @@ bool Network::Compile(const Flow &flow, const Library &library) {
         tensor->aligned_.set(d, align);
         size *= align;
       }
+      outer = tensor->rank();
     }
+
+    // For tensors where the size of the outer dimension is one, the stride of
+    // the first dimension is adjusted to the byte alignment requirement for the
+    // tensor. This ensures that channels allocated using this tensor as the
+    // format will have the correct alignment for all the elements.
+    if (tensor->rank() > 1 &&
+        tensor->shape_.dim(outer) == 1 &&
+        size % tensor->byte_alignment_ != 0) {
+      tensor->stride_.set(outer, Align(size, tensor->byte_alignment_));
+    }
+
+    // Set tensor size.
     tensor->size_ = size;
     tensor->space_ = tensor->ref() ? sizeof(void *) : size;
 


### PR DESCRIPTION
A channel is created with a tensor as the element template so each element would have the same format as the tensor. The tenor can have byte alignment requirements which so each element in the channel needed padding. This work fine for cases where the channel elements are used as single element inputs or output to a network cell. However, some kernels like Collect, views the channel reference as an array of elements. In this case, the kernel uses the stride(0) to determine the size of each element. If the channel elements needed padding, this could lead to errors in index calculations.

I have added a fix so the padding is added to stride(0) to account for the padding. This fixes the error, but it also slightly changes the semantics of the channel format. The channel format tensor used to be the format of a single element of the channel. It is now required that the format used for a channel is a _template_ for the channel tensor format where the first dimension can be variable-size. This change should not affect any of our existing models because we have a batch dimension on all tensors.